### PR TITLE
FEAT: 시리즈 화면 데이터 뷰단에 연결

### DIFF
--- a/Todorama/Global/Resources/Strings.swift
+++ b/Todorama/Global/Resources/Strings.swift
@@ -16,6 +16,9 @@ enum Strings {
         case watching
         case comment
         case rate
+        case season
+        case countUnit
+        case episode
         
         var text: String {
             switch self {
@@ -31,6 +34,12 @@ enum Strings {
                 "코멘트"
             case .rate:
                 "별점"
+            case .season:
+                "시즌"
+            case .countUnit:
+                "개"
+            case .episode:
+                "에피소드"
             }
         }
     }

--- a/Todorama/Presentation/Series/SeriesCollectionViewCell.swift
+++ b/Todorama/Presentation/Series/SeriesCollectionViewCell.swift
@@ -37,7 +37,6 @@ final class SeriesCollectionViewCell: UICollectionViewCell {
     }
     
     private func configurePosterImageView() {
-        posterImageView.backgroundColor = .tdMain
         posterImageView.contentMode = .scaleAspectFill
         posterImageView.clipsToBounds = true
         posterImageView.layer.cornerRadius = 4
@@ -69,10 +68,10 @@ final class SeriesCollectionViewCell: UICollectionViewCell {
     
     func bindData(with season: Season) {
         titleLabel.text = season.name
-        episodeCountLabel.text = "\(season.episode_count)개 에피소드"
+        episodeCountLabel.text = "\(season.episode_count)\(Strings.Global.countUnit.text) \(Strings.Global.episode.text)"
         
         if let image = season.poster_path {
-            posterImageView.kf.setImage(with: URL(string: image))
+            posterImageView.kf.setImage(with: URL(string: ImageSize.poster154(url: image).fullUrl))
         } else {
             posterImageView.backgroundColor = .darkGray
         }

--- a/Todorama/Presentation/Series/SeriesCollectionViewCell.swift
+++ b/Todorama/Presentation/Series/SeriesCollectionViewCell.swift
@@ -64,18 +64,17 @@ final class SeriesCollectionViewCell: UICollectionViewCell {
             make.top.equalTo(titleLabel.snp.bottom).offset(4)
             make.centerX.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(4)
-//            make.bottom.equalToSuperview().inset(8)
         }
     }
     
-//    func configure(with series: Series) {
-//        titleLabel.text = series.title
-//        episodeCountLabel.text = "\(series.episodeCount)개 에피소드"
-//        
-//        if let image = series.posterImage {
-//            posterImageView.image = image
-//        } else {
-//            posterImageView.backgroundColor = .darkGray
-//        }
-//    }
+    func bindData(with season: Season) {
+        titleLabel.text = season.name
+        episodeCountLabel.text = "\(season.episode_count)개 에피소드"
+        
+        if let image = season.poster_path {
+            posterImageView.kf.setImage(with: URL(string: image))
+        } else {
+            posterImageView.backgroundColor = .darkGray
+        }
+    }
 }

--- a/Todorama/Presentation/Series/SeriesViewController.swift
+++ b/Todorama/Presentation/Series/SeriesViewController.swift
@@ -50,19 +50,22 @@ final class SeriesViewController: BaseViewController {
         output.result
             .map { $0.seasons }
             .asDriver(onErrorJustReturn: [])
-            .drive(seriesCollectionView.rx.items(cellIdentifier: SeriesCollectionViewCell.identifier, cellType: SeriesCollectionViewCell.self)) {(row, element, cell) in
+            .drive(seriesCollectionView.rx.items(
+                cellIdentifier: SeriesCollectionViewCell.identifier,
+                cellType: SeriesCollectionViewCell.self)) {(row, element, cell) in
 
                 cell.bindData(with: element)
-                
             }
             .disposed(by: disposeBag)
 
     }
     
     private func updateUI(with series: Series) {
-        backdropView.kf.setImage(with: URL(string: series.backdrop_path ?? ""))
+        if let image = series.backdrop_path {
+            backdropView.kf.setImage(with: URL(string: ImageSize.backdrop780(url: image).fullUrl))
+        }
         dramaTitleLabel.text = series.name
-        infoLabel.text = "시즌 \(series.number_of_seasons)개 · \(series.status) · \(series.genres[0].name)"
+        infoLabel.text = "\(Strings.Global.season.text) \(series.number_of_seasons)\(Strings.Global.countUnit.text) · \(series.status) · \(series.genres[0].name)"
         synopsisLabel.text = series.overview
         
         seriesCollectionView.reloadData()
@@ -119,7 +122,6 @@ final class SeriesViewController: BaseViewController {
         
         backdropView.contentMode = .scaleAspectFill
         backdropView.clipsToBounds = true
-        backdropView.backgroundColor = .tdMain
         
         dramaTitleLabel.navTitleStyle()
         
@@ -139,8 +141,7 @@ final class SeriesViewController: BaseViewController {
         seriesCollectionView.backgroundColor = .clear
         seriesCollectionView.showsHorizontalScrollIndicator = false
         seriesCollectionView.register(SeriesCollectionViewCell.self, forCellWithReuseIdentifier: "SeriesCollectionViewCell")
-//        seriesCollectionView.delegate = self
-//        seriesCollectionView.dataSource = self
+
     }
     
     private func createRelatedSeriesLayout() -> UICollectionViewLayout {

--- a/Todorama/Presentation/Series/SeriesViewController.swift
+++ b/Todorama/Presentation/Series/SeriesViewController.swift
@@ -35,10 +35,10 @@ final class SeriesViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        loadSeriesData()
+
     }
     
-    private func loadSeriesData() {
+    override func bind() {
         let input = SeriesViewModel.Input()
         let output = viewModel.transform(input: input)
         
@@ -46,6 +46,16 @@ final class SeriesViewController: BaseViewController {
             owner.updateUI(with: series)
             print(series)
         }.disposed(by: disposeBag)
+        
+        output.result
+            .map { $0.seasons }
+            .asDriver(onErrorJustReturn: [])
+            .drive(seriesCollectionView.rx.items(cellIdentifier: SeriesCollectionViewCell.identifier, cellType: SeriesCollectionViewCell.self)) {(row, element, cell) in
+
+                cell.bindData(with: element)
+                
+            }
+            .disposed(by: disposeBag)
 
     }
     
@@ -155,21 +165,3 @@ final class SeriesViewController: BaseViewController {
     
   
 }
-
-// MARK: - UICollectionViewDataSource, UICollectionViewDelegate
-//extension SeriesViewController: UICollectionViewDataSource, UICollectionViewDelegate {
-//    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-//        return 10
-//    }
-//    
-//    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-//        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "SeriesCollectionViewCell", for: indexPath) as? SeriesCollectionViewCell else {
-//            return UICollectionViewCell()
-//        }
-//        
-//        let series = DummyData.shared.series[indexPath.item]
-//        cell.configure(with: series)
-//        
-//        return cell
-//    }
-//}

--- a/Todorama/Presentation/Series/SeriesViewModel.swift
+++ b/Todorama/Presentation/Series/SeriesViewModel.swift
@@ -18,19 +18,19 @@ final class SeriesViewModel: BaseViewModel {
     }
     
     struct Input {
-//        let onViewDidLoad: Observable<Void>
+
     }
     
     struct Output {
-        var result: PublishRelay<Series>
+        var result: PublishSubject<Series>
     }
     
     func transform(input: Input) -> Output {
-        let result = PublishRelay<Series>()
+        let result = PublishSubject<Series>()
         
         NetworkManager.shared.callRequest(target: .series(id: self.id ?? -1), model: Series.self)
             .subscribe(with: self) { owner, response in
-                result.accept(response)
+                result.onNext(response)
             }
             .disposed(by: disposeBag)
 
@@ -39,7 +39,4 @@ final class SeriesViewModel: BaseViewModel {
         )
     }
     
-//    private func callRequest(id: Int) -> Observable<Series> {
-//        return
-//    }
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타: 변경사항

### 반영 브랜치
21-feat-series-data -> main

### 변경 사항
- 시리즈 화면 ViewModel에서 네트워크 통해 받아온 데이터 연결
- 이미지 Url이 베이스 없이 값이 오기 때문에 라우터에 베이스 Url 붙이는 열거형 추가
- 문자열 내용 추가

### 테스트 사항
- 화면에 잘 나오는 것 확인했습니다!
