### PR TITLE
REFACTOR:  BackdropCollectionViewCell 리터럴 하게 작성된 image 로딩 url 열거형으로 수정

### DIFF
--- a/Todorama/Global/Resources/Strings.swift
+++ b/Todorama/Global/Resources/Strings.swift
@@ -36,6 +36,8 @@ enum Strings {
         case season
         case episode
         case air
+        case none // 추가
+        case empty  // 추가
         
         var text: String {
             switch self {
@@ -57,6 +59,10 @@ enum Strings {
                 "에피소드"
             case .air:
                 "방영"
+            case .none: // 추가
+                "none"
+            case .empty: // 추가
+                ""
             }
         }
     }

--- a/Todorama/Network/Model/Popular.swift
+++ b/Todorama/Network/Model/Popular.swift
@@ -13,6 +13,7 @@ struct Popular: Decodable, Hashable {
 }
 struct PopularDetail: Decodable, Hashable, IdentifiableModel {
     let id: Int
+    let name: String? // If PosterPath doens't exist show name for title label!
     let poster_path: String?
 }
 


### PR DESCRIPTION


### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타: 

### 반영 브랜치
41-refactor-postercell-back...-> main

### 변경 사항
- 백드롭 패스 셀 case .poster154(let url): 사용
- 셀이 이미지 정보를 갖고 있지 않으면 드라마 타이틀 표시하도록 수정
- 모서리 둥글기 수정
- Strings global → none empty 케이스 추가
### 테스트 사항

