### PR TITLE
FIX: Search화면의 PosterCell의 reuseCell초기화

### DIFF
--- a/Todorama/Presentation/Custom/PosterCollectionViewCell.swift
+++ b/Todorama/Presentation/Custom/PosterCollectionViewCell.swift
@@ -27,6 +27,7 @@ final class PosterCollectionViewCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         print(#function)
+        imageView.isHidden = false
         imageView.image = nil
         label.text = nil
         emptyLabel.text = nil


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타: 변경사항

### 반영 브랜치
53-feat-search-cell-reuse -> main

### 변경 사항
- Search화면 PosterCell Reuse 초기화

### 테스트 사항
 - 빌드 문제 없음