### PR TITLE
FEAT: 시리즈 화면 UI 수정 및 네트워크 작업 추가

### DIFF
--- a/Todorama/Network/Model/Series.swift
+++ b/Todorama/Network/Model/Series.swift
@@ -31,6 +31,14 @@ struct Network: Decodable {
     let name: String
 }
 
+struct NetworkDetail: Decodable {
+    let id: Int
+    let homepage: String
+    let logo_path: String
+    let name: String
+    let origin_country: String
+}
+
 struct Season: Decodable {
     let id: Int
     let air_date: String?

--- a/Todorama/Presentation/Episode/EpisodeViewController.swift
+++ b/Todorama/Presentation/Episode/EpisodeViewController.swift
@@ -104,53 +104,26 @@ final class EpisodeViewController: BaseViewController {
     override func bind() {
         let input = EpisodeViewModel.Input()
         let output = viewModel.transform(input: input)
-        
-        
-        
-//        output.result
- //            .map { $0.seasons }
- //            .asDriver(onErrorJustReturn: [])
- //            .drive(seriesCollectionView.rx.items(
- //                cellIdentifier: SeriesCollectionViewCell.identifier,
- //                cellType: SeriesCollectionViewCell.self)) {(row, element, cell) in
- //
- //                cell.bindData(with: element)
- //            }
- //            .disposed(by: disposeBag)
-        
+
         output.result
             .asDriver(onErrorJustReturn: SeasonDetail(name: "", overview: "", id: -1, poster_path: "", season_number: -1, episodes: []))
-             .drive(with: self, onNext: { owner, detail in
-                 owner.loadData(with: detail)
-                 
-                 // 시즌 방출 -> 컬렉션 뷰
-                 Observable.just(detail.episodes)
-                     .asDriver(onErrorJustReturn: [])
-                     .drive(owner.episodesTableView.rx.items(
-                        cellIdentifier: EpisodeTableViewCell.identifier,
-                         cellType: EpisodeTableViewCell.self)) {(row, element, cell) in
-                             cell.bindData(with: element)
-                         }
-                     .disposed(by: owner.disposeBag)
-             })
-             .disposed(by: disposeBag)
+            .drive(with: self, onNext: { owner, detail in
+                owner.dramaTitleLabel.text = detail.name
+                owner.episodeCountLabel.text = "\(detail.season_number)\(Strings.Unit.count.text) \(Strings.Global.episode.text)"
+                owner.synopsisLabel.text = detail.overview
+                if let posterPath = detail.poster_path {
+                    owner.posterView.kf.setImage(with: URL(string: ImageSize.poster185(url: posterPath).fullUrl))
+                }
+            })
+            .disposed(by: disposeBag)
         
-//        output.result
-//            .map { $0.episodes }
-//            .asDriver(onErrorJustReturn: [])
-//            .drive(episodesTableView.rx.items(
-//                cellIdentifier: EpisodeTableViewCell.identifier,
-//                cellType: EpisodeTableViewCell.self)) {(row, element, cell) in
-//                    cell.bindData(with: element)
-//                    self.loadData(with: element)
-//                }
-//            .disposed(by: disposeBag)
-   
-//        episodesTableView.rx.itemSelected
-//            .subscribe(onNext: { [weak self] indexPath in
-//                self?.episodesTableView.deselectRow(at: indexPath, animated: true)
-//            })
-//            .disposed(by: disposeBag)
+        output.result
+            .map { $0.episodes }
+            .asDriver(onErrorJustReturn: [])
+            .drive(episodesTableView.rx.items(cellIdentifier: EpisodeTableViewCell.identifier, cellType: EpisodeTableViewCell.self)) { row, episode, cell in
+                cell.bindData(with: episode)
+            }
+            .disposed(by: disposeBag)
     }
     
     

--- a/Todorama/Presentation/Episode/EpisodeViewModel.swift
+++ b/Todorama/Presentation/Episode/EpisodeViewModel.swift
@@ -32,6 +32,7 @@ final class EpisodeViewModel: BaseViewModel {
         let result = PublishSubject<SeasonDetail>()
         
         NetworkManager.shared.callRequest(target: .episode(id: id, season: season), model: SeasonDetail.self)
+            .share(replay: 1, scope: .whileConnected)
             .subscribe(with: self) { owner, response in
                 result.onNext(response)
             }

--- a/Todorama/Presentation/Series/NetworkButtonView.swift
+++ b/Todorama/Presentation/Series/NetworkButtonView.swift
@@ -1,0 +1,84 @@
+//
+//  NetworkButtonView.swift
+//  Todorama
+//
+//  Created by Claire on 3/25/25.
+//
+
+import UIKit
+import Kingfisher
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class NetworkButtonView: UIView {
+    private let disposeBag = DisposeBag()
+    
+    private let logoImageView = UIImageView()
+    private let button = UIButton(type: .custom)
+    private let chevron = UIImageView()
+    
+    var onTap: (() -> Void)?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureHierarchy()
+        configureLayout()
+        configureView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configureHierarchy() {
+        addSubview(logoImageView)
+        addSubview(button)
+        addSubview(chevron)
+    }
+    
+    private func configureLayout() {
+        logoImageView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(12)
+            make.centerY.equalToSuperview()
+            make.width.equalTo(60)
+            make.height.equalTo(18)
+        }
+        
+        chevron.snp.makeConstraints { make in
+            make.size.equalTo(22)
+            make.trailing.equalToSuperview().inset(12)
+            make.centerY.equalToSuperview()
+        }
+        
+        button.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    
+    private func configureView() {
+        backgroundColor = .tdDarkGray
+        layer.cornerRadius = 6
+        clipsToBounds = true
+        
+        logoImageView.contentMode = .scaleAspectFit
+        logoImageView.clipsToBounds = true
+        
+        chevron.contentMode = .scaleAspectFit
+        chevron.image = SystemImages.chevron.right.image
+        chevron.tintColor = .tdMain
+        
+        button.rx.tap
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.onTap?()
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func configure(with network: Network) {
+        let url = URL(string: ImageSize.profile185(url: network.logo_path).fullUrl)
+        logoImageView.kf.setImage(with: url, placeholder: nil)
+        
+    }
+ 
+}

--- a/Todorama/Presentation/Series/SeriesCollectionViewCell.swift
+++ b/Todorama/Presentation/Series/SeriesCollectionViewCell.swift
@@ -42,11 +42,6 @@ final class SeriesCollectionViewCell: UICollectionViewCell {
         posterImageView.layer.cornerRadius = 4
     }
     
-    private func configureLabels() {
-        titleLabel.dramaTitleStyle()
-        episodeCountLabel.textStyle()
-    }
-    
     private func setupConstraints() {
         posterImageView.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
@@ -63,7 +58,15 @@ final class SeriesCollectionViewCell: UICollectionViewCell {
             make.top.equalTo(titleLabel.snp.bottom).offset(4)
             make.centerX.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(4)
+            make.bottom.equalToSuperview().offset(-8)
         }
+    }
+
+    private func configureLabels() {
+        titleLabel.dramaTitleStyle()
+        titleLabel.numberOfLines = 1
+        episodeCountLabel.textStyle()
+        episodeCountLabel.numberOfLines = 1
     }
     
     func bindData(with season: Season) {

--- a/Todorama/Presentation/Series/SeriesViewModel.swift
+++ b/Todorama/Presentation/Series/SeriesViewModel.swift
@@ -30,6 +30,7 @@ final class SeriesViewModel: BaseViewModel {
         let result = PublishSubject<Series>()
         
         NetworkManager.shared.callRequest(target: .series(id: self.id), model: Series.self)
+            .share(replay: 1, scope: .whileConnected)
             .subscribe(with: self) { owner, response in
                 result.onNext(response)
             }

--- a/Todorama/Presentation/Series/SeriesViewModel.swift
+++ b/Todorama/Presentation/Series/SeriesViewModel.swift
@@ -19,26 +19,34 @@ final class SeriesViewModel: BaseViewModel {
     }
     
     struct Input {
-
+   
     }
     
     struct Output {
-        var result: PublishSubject<Series>
+        let result: Observable<Series>
+        let homepage: Observable<String>
     }
     
     func transform(input: Input) -> Output {
-        let result = PublishSubject<Series>()
-        
-        NetworkManager.shared.callRequest(target: .series(id: self.id), model: Series.self)
+        let result = NetworkManager.shared.callRequest(target: .series(id: self.id), model: Series.self)
             .share(replay: 1, scope: .whileConnected)
-            .subscribe(with: self) { owner, response in
-                result.onNext(response)
-            }
-            .disposed(by: disposeBag)
 
+        let networkDetail = result
+            .flatMapLatest { series -> Observable<NetworkDetail> in
+                guard let networkId = series.networks.first?.id else {
+                    return .just(NetworkDetail(id: -1, homepage: "", logo_path: "", name: "", origin_country: ""))
+                }
+                return NetworkManager.shared.callRequest(target: .network(id: networkId), model: NetworkDetail.self)
+            }
+            .share(replay: 1, scope: .whileConnected)
+        
+        let homepage = networkDetail
+            .map { $0.homepage }
+            .catchAndReturn("https://www.google.com") // 에러 발생 시
+        
         return Output(
-            result: result
+            result: result,
+            homepage: homepage
         )
     }
-    
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타: 변경사항

### 반영 브랜치
46-feat-series-detail -> main

### 변경 사항
- 네트워크 요청 추가하였습니다. (라우터 파일 잔디를 통해 따로 공유 예정입니다!)
- 홈페이지 얻어오는 네트워크 작업을 통해 웹킷을 통한 홈페이지 화면 이동 구현하였습니다.
- 오버뷰 내용이 길어짐에 따라 UI가 잘리는 문제 해결하기 위해 전체 화면 스크롤 뷰로 감쌌습니다.
- 시즌에 해당하는 셀 클릭시 에피소드 화면으로 이동합니다.

### 테스트 사항
- 화면 이동 및 네트워크로부터 전달 받은 데이터가 잘 보이는 것을 확인했습니다.
