### PR TITLE
FEAT: 보고싶어요 버튼 기능 구현, 시리즈 시청 진행률 저장 구현

### DIFF
--- a/Todorama/Database/DatabaseModel/Watching.swift
+++ b/Todorama/Database/DatabaseModel/Watching.swift
@@ -25,3 +25,33 @@ class Watching: Object, RealmFetchable {
     }
 }
 
+class Watching2: Object, RealmFetchable {
+    @Persisted(primaryKey: true) var dramaId: Int // 시리즈 아이디
+    @Persisted var dramaName: String // 시리즈 이름
+    @Persisted var seasonNumber: Int // 시즌 넘버
+    @Persisted var episodeIds: List<Int> // 체크된 에피소드
+    @Persisted var episodeCount: Int // 총 에피소드 갯수
+    @Persisted var stillCutPath: String? // 에피소드 1화 이미지
+
+    convenience init(dramaId: Int, dramaName: String, seasonNumber: Int, episodeIds: [Int], episodeCount: Int, stillCutPath: String? = nil) {
+        self.init()
+        self.dramaId = dramaId
+        self.dramaName = dramaName
+        self.seasonNumber = seasonNumber
+        self.episodeIds.append(objectsIn: episodeIds)
+        self.episodeCount = episodeCount
+        self.stillCutPath = stillCutPath
+    }
+    
+}
+
+
+struct Watching3 {
+    let dramaId: Int // 시리즈 아이디
+    let dramaName: String // 시리즈 이름
+    let seasonNumber: Int // 시즌 넘버
+    let episodeId: Int // 체크된 에피소드
+    let episodeCount: Int // 총 에피소드 갯수
+    let stillCutPath: String? // 에피소드 1화 이미지
+    
+}

--- a/Todorama/Database/DatabaseModel/Watching.swift
+++ b/Todorama/Database/DatabaseModel/Watching.swift
@@ -26,18 +26,18 @@ class Watching: Object, RealmFetchable {
 }
 
 class Watching2: Object, RealmFetchable {
-    @Persisted(primaryKey: true) var dramaId: Int // 시리즈 아이디
+    @Persisted(primaryKey: true) var seasonId: Int // 시즌 아이디
+    @Persisted var dramaId: Int // 시리즈 아이디
     @Persisted var dramaName: String // 시리즈 이름
-    @Persisted var seasonNumber: Int // 시즌 넘버
     @Persisted var episodeIds: List<Int> // 체크된 에피소드
     @Persisted var episodeCount: Int // 총 에피소드 갯수
     @Persisted var stillCutPath: String? // 에피소드 1화 이미지
 
-    convenience init(dramaId: Int, dramaName: String, seasonNumber: Int, episodeIds: [Int], episodeCount: Int, stillCutPath: String? = nil) {
+    convenience init(seasonId: Int, dramaId: Int, dramaName: String, episodeIds: [Int], episodeCount: Int, stillCutPath: String? = nil) {
         self.init()
+        self.seasonId = seasonId
         self.dramaId = dramaId
         self.dramaName = dramaName
-        self.seasonNumber = seasonNumber
         self.episodeIds.append(objectsIn: episodeIds)
         self.episodeCount = episodeCount
         self.stillCutPath = stillCutPath
@@ -49,7 +49,7 @@ class Watching2: Object, RealmFetchable {
 struct Watching3 {
     let dramaId: Int // 시리즈 아이디
     let dramaName: String // 시리즈 이름
-    let seasonNumber: Int // 시즌 넘버
+    let seasonId: Int // 시즌 넘버
     let episodeId: Int // 체크된 에피소드
     let episodeCount: Int // 총 에피소드 갯수
     let stillCutPath: String? // 에피소드 1화 이미지

--- a/Todorama/Database/DatabaseRepository.swift
+++ b/Todorama/Database/DatabaseRepository.swift
@@ -55,6 +55,21 @@ final class DatabaseRepository: DatabaseRepositoryPr {
             print("아이템 삭제 실패: \(error)")
         }
     }
+    
+    
+    func updateEpisodeIds<T: RealmFetchable>(itemId: Int, newEpisodeIds: [Int], type: T) {
+        do {
+            try realm.write {
+                if let target = realm.objects(T.self).where({ $0.dramaId == itemId }).first as? Watching {
+                    target.episodeIds.removeAll() // 기존 리스트 삭제
+                    target.episodeIds.append(objectsIn: newEpisodeIds) // 새로운 리스트 추가
+                }
+            }
+        } catch {
+            print("리스트 수정 실패: \(error)")
+        }
+    }
+    
 }
 
 final class MockRepository: DatabaseRepositoryPr {

--- a/Todorama/Global/Resources/SystemImages.swift
+++ b/Todorama/Global/Resources/SystemImages.swift
@@ -8,13 +8,6 @@
 import UIKit
 
 enum SystemImages {
-    case star
-    case plus
-    case check
-    case eye
-    case pencil
-    case heart
-    
     enum tab {
         case houseICON
         case magnifICON
@@ -32,10 +25,20 @@ enum SystemImages {
         }
     }
     
+    case star
+    case starRate
+    case plus
+    case check
+    case eye
+    case pencil
+    case heart
+    
     var name: String {
         switch self {
         case .star:
             "star.circle.fill"
+        case .starRate:
+            "star.fill"
         case .plus:
             "plus.circle.fill"
         case .check:
@@ -45,7 +48,7 @@ enum SystemImages {
         case .pencil:
             "square.and.pencil.circle.fill"
         case .heart:
-            "heart.fill"
+            "heart.circle.fill"
         }
     }
     

--- a/Todorama/Global/Resources/SystemImages.swift
+++ b/Todorama/Global/Resources/SystemImages.swift
@@ -31,6 +31,7 @@ enum SystemImages {
     case check
     case eye
     case pencil
+    case heartLine
     case heart
     
     var name: String {
@@ -47,6 +48,8 @@ enum SystemImages {
             "eye.circle.fill"
         case .pencil:
             "square.and.pencil.circle.fill"
+        case .heartLine:
+            "heart"
         case .heart:
             "heart.fill"
         }

--- a/Todorama/Global/Resources/SystemImages.swift
+++ b/Todorama/Global/Resources/SystemImages.swift
@@ -48,7 +48,7 @@ enum SystemImages {
         case .pencil:
             "square.and.pencil.circle.fill"
         case .heart:
-            "heart.circle.fill"
+            "heart.fill"
         }
     }
     

--- a/Todorama/Network/Model/Episode.swift
+++ b/Todorama/Network/Model/Episode.swift
@@ -21,7 +21,7 @@ struct Episode: Decodable, IdentifiableModel {
     let id: Int
     let name: String
     let overview: String
-    let air_date: String
+    let air_date: String?
     let episode_number: Int
     let episode_type: String
     let runtime: Int?

--- a/Todorama/Presentation/Base/BaseViewController.swift
+++ b/Todorama/Presentation/Base/BaseViewController.swift
@@ -16,6 +16,11 @@ class BaseViewController: UIViewController {
         configureLayout()
         configureView()
         bind()
+        
+        navigationController?.navigationBar.topItem?.backButtonTitle = Strings.Global.empty.text
+        navigationController?.navigationBar.tintColor = .tdMain
+        navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white]
+
     }
     
     

--- a/Todorama/Presentation/Custom/CheckButton.swift
+++ b/Todorama/Presentation/Custom/CheckButton.swift
@@ -1,0 +1,105 @@
+//
+//  CheckButton.swift
+//  Todorama
+//
+//  Created by Claire on 3/25/25.
+//
+
+import UIKit
+import RealmSwift
+import RxCocoa
+import RxSwift
+
+final class CheckButton: UIButton {
+    private let disposeBag = DisposeBag()
+
+    private let realm = try! Realm()
+    private var watchingInfo: Watching3?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureView()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setSeries(info: Watching3?) {
+        self.watchingInfo = info
+        updateWatchingButtonState()
+    }
+    
+    private func configureView() {
+        tintColor = .tdGray
+        setImage(SystemImages.check.image, for: .normal)
+        self.rx.tap.subscribe(with: self) { owner, _ in
+            owner.onButtonTapped()
+        }
+        .disposed(by: disposeBag)
+    }
+    
+    private func isWatching() -> Bool {
+        guard let watchingInfo else { return false }
+        return !realm.objects(Watching2.self).where({ $0.dramaId == watchingInfo.dramaId }).isEmpty
+    }
+    
+    private func writeTable() {
+        guard let watchingInfo else { return }
+        do {
+            let isWatching = isWatching()
+            
+            try realm.write {
+                // 1. 이미 있을 경우 - 에피소드만 제거
+                if isWatching {
+                    if let existingData = realm.objects(Watching2.self).where({ $0.dramaId == watchingInfo.dramaId }).first {
+                        
+                        // 1-1. 에피소드가 있을 경우
+                        if let index = existingData.episodeIds.index(of: watchingInfo.episodeId) {
+                            existingData.episodeIds.remove(at: index)
+                        // 1-2. 에피소드가 없을 경우
+                        } else {
+                            existingData.episodeIds.append(watchingInfo.episodeId)
+                        }
+                        
+                        // 에피소드가 모두 제거 되었을 경우 해당 내용 삭제
+                        if existingData.episodeIds.isEmpty {
+                            realm.delete(existingData)
+                        }
+                        
+                    }
+                // 2. 새로 추가하는 경우
+                } else {
+                    let data = Watching2(dramaId: watchingInfo.dramaId,
+                                         dramaName: watchingInfo.dramaName,
+                                         seasonNumber: watchingInfo.seasonNumber,
+                                         episodeIds: [watchingInfo.episodeId],
+                                         episodeCount: watchingInfo.episodeCount,
+                                         stillCutPath: watchingInfo.stillCutPath)
+                    realm.add(data)
+                }
+                
+                updateWatchingButtonState()
+            }
+            print("realm 저장 완료")
+            
+        } catch {
+            print("realm 저장 실패: \(error.localizedDescription)")
+        }
+        
+    }
+    
+    @objc
+    private func onButtonTapped() {
+        writeTable()
+    }
+    
+    func updateWatchingButtonState() {
+        let isWatching = isWatching()
+        tintColor = isWatching ? .tdMain : .tdGray
+    }
+    
+}
+
+

--- a/Todorama/Presentation/Custom/WishButton.swift
+++ b/Todorama/Presentation/Custom/WishButton.swift
@@ -10,16 +10,6 @@ import RealmSwift
 import RxCocoa
 import RxSwift
 
-//final class WishButton: Object {
-//    @Persisted(primaryKey: true) var id:  ObjectId
-//    @Persisted(indexed: true) var itemId: Int
-//    
-//    convenience init(itemId: Int) {
-//        self.init()
-//        self.itemId = itemId
-//    }
-//}
-
 final class WishButton: UIButton {
     private let disposeBag = DisposeBag()
 
@@ -73,9 +63,6 @@ final class WishButton: UIButton {
                 }
                 
                 updateWishButtonState()
-                
-//                NotificationCenter.default.post(name: .interestNoti,
-//                                                object: nil)
             }
             print("realm 저장 완료")
             
@@ -88,7 +75,6 @@ final class WishButton: UIButton {
     @objc
     private func onButtonTapped() {
         writeTable()
-//        NotificationCenter.default.post(name: .interestNoti, object: nil, userInfo: nil)
     }
     
     func updateWishButtonState() {

--- a/Todorama/Presentation/Custom/WishButton.swift
+++ b/Todorama/Presentation/Custom/WishButton.swift
@@ -1,0 +1,102 @@
+//
+//  WishButton.swift
+//  Todorama
+//
+//  Created by Claire on 3/25/25.
+//
+
+import UIKit
+import RealmSwift
+import RxCocoa
+import RxSwift
+
+//final class WishButton: Object {
+//    @Persisted(primaryKey: true) var id:  ObjectId
+//    @Persisted(indexed: true) var itemId: Int
+//    
+//    convenience init(itemId: Int) {
+//        self.init()
+//        self.itemId = itemId
+//    }
+//}
+
+final class WishButton: UIButton {
+    private let disposeBag = DisposeBag()
+
+    private let realm = try! Realm()
+    private var series: Series?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureView()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setSeries(series: Series) {
+        self.series = series
+        updateWishButtonState()
+    }
+    
+    private func configureView() {
+        tintColor = .tdMain
+        self.rx.tap.subscribe(with: self) { owner, _ in
+            owner.onButtonTapped()
+        }
+        .disposed(by: disposeBag)
+    }
+    
+    private func isWished() -> Bool {
+        guard let series else { return false }
+        return !realm.objects(Drama.self).where({ $0.dramaId == series.id }).isEmpty
+    }
+    
+    private func writeTable() {
+        guard let series else { return }
+        do {
+            let isWished = isWished()
+            
+            try realm.write {
+                // 1. 이미 있을 경우
+                if isWished {
+                    if let oldData = realm.objects(Drama.self).where({ $0.dramaId == series.id }).first {
+                        realm.delete(oldData)
+                    }
+                // 2. 새로 추가하는 경우
+                } else {
+                    let genre = series.genres.first?.id ?? 00
+                    let data = Drama(dramaId: series.id, name: series.name, backdropPath: series.backdrop_path ?? Strings.Global.empty.text, genre: genre)
+                    realm.add(data)
+                }
+                
+                updateWishButtonState()
+                
+//                NotificationCenter.default.post(name: .interestNoti,
+//                                                object: nil)
+            }
+            print("realm 저장 완료")
+            
+        } catch {
+            print("realm 저장 실패: \(error.localizedDescription)")
+        }
+        
+    }
+    
+    @objc
+    private func onButtonTapped() {
+        writeTable()
+//        NotificationCenter.default.post(name: .interestNoti, object: nil, userInfo: nil)
+    }
+    
+    func updateWishButtonState() {
+        let isWished = isWished()
+        let wishImage = isWished ? SystemImages.heart.image : SystemImages.heartLine.image
+        setImage(wishImage, for: .normal)
+    }
+    
+}
+
+

--- a/Todorama/Presentation/Editing/EditingCommentViewController.swift
+++ b/Todorama/Presentation/Editing/EditingCommentViewController.swift
@@ -1,0 +1,73 @@
+//
+//  EditingCommentViewController.swift
+//  Todorama
+//
+//  Created by Claire on 3/20/25.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class EditingCommentViewController: BaseViewController {
+    
+    private let commentTextView: UITextView = {
+        let textView = UITextView()
+        textView.backgroundColor = .tdDarkGray
+        textView.layer.borderColor = UIColor.systemGray4.cgColor
+        textView.layer.borderWidth = 1
+        textView.layer.cornerRadius = 4
+        textView.font = Fonts.textFont
+        textView.textContainerInset = UIEdgeInsets(top: 8, left: 4, bottom: 8, right: 4)
+        textView.textColor = .tdGray
+        return textView
+    }()
+    
+    private let characterCountLabel: UILabel = {
+        let label = UILabel()
+        label.text = "0/500"
+        label.textStyle()
+        return label
+    }()
+    
+    private let disposeBag = DisposeBag()
+    
+    override func configureHierarchy() {
+        view.addSubview(commentTextView)
+        view.addSubview(characterCountLabel)
+    }
+    
+    override func configureLayout() {
+        commentTextView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(20)
+            make.horizontalEdges.equalToSuperview().inset(12)
+            make.height.equalTo(400)
+        }
+        
+        characterCountLabel.snp.makeConstraints { make in
+            make.trailing.equalTo(commentTextView.snp.trailing).offset(-8)
+            make.bottom.equalTo(commentTextView.snp.bottom).offset(-8)
+        }
+    }
+    
+    override func bind() {
+        let maxCharacterCount = 500
+        
+        commentTextView.rx.text.orEmpty
+            .map { text -> String in
+                let trimmedText = String(text.prefix(maxCharacterCount))
+                return trimmedText
+            }
+            .bind(to: commentTextView.rx.text)
+            .disposed(by: disposeBag)
+        
+        commentTextView.rx.text.orEmpty
+            .map { text -> String in
+                "\(text.count)/\(maxCharacterCount)"
+            }
+            .bind(to: characterCountLabel.rx.text)
+            .disposed(by: disposeBag)
+
+    }
+}

--- a/Todorama/Presentation/Episode/ButtonStack.swift
+++ b/Todorama/Presentation/Episode/ButtonStack.swift
@@ -1,18 +1,42 @@
+//
+//  ButtonStack.swift
+//  Todorama
+//
+//  Created by Claire on 3/22/25.
+//
 import UIKit
 import SnapKit
 import RxSwift
 import RxCocoa
 
 final class ButtonStack: UIStackView {
+    
     private let wantToWatchButton = UIButton()
     private let commentButton = UIButton()
     private let rateButton = UIButton()
+    
+    private let ratingOptions: [Double] = Array(stride(from: 0.0, through: 5.0, by: 0.5)).map { $0 }
+    
+    private lazy var ratePickerView: UIPickerView = {
+        let picker = UIPickerView()
+        return picker
+    }()
+    
+    private lazy var rateTextField: UITextField = {
+        let textField = UITextField()
+        textField.inputView = ratePickerView
+        textField.inputAccessoryView = setupInputAccessoryView()
+        textField.text = "0.0"
+        return textField
+    }()
     
     private let disposeBag = DisposeBag()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupButtonStack()
+        setupRateTextField()
+        setupPickerBinding()
     }
     
     required init(coder: NSCoder) {
@@ -77,20 +101,76 @@ final class ButtonStack: UIStackView {
     private func setupBindings() {
         wantToWatchButton.rx.tap
             .subscribe(with: self, onNext: { owner, _ in
-                print("보고싶어요 클릭")
+                print("🌟 WANT TO WATCH")
             })
             .disposed(by: disposeBag)
         
         commentButton.rx.tap
             .subscribe(with: self, onNext: { owner, _ in
-                print("코멘트 클릭")
+                print("🌟 COMMENT")
             })
             .disposed(by: disposeBag)
         
         rateButton.rx.tap
             .subscribe(with: self, onNext: { owner, _ in
-                print("별점 클릭")
+                print("🌟 RATE")
+                owner.showRatePicker()
             })
             .disposed(by: disposeBag)
+    }
+    
+    private func setupRateTextField() {
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let window = windowScene.windows.first {
+            window.addSubview(rateTextField)
+            rateTextField.isHidden = true
+        }
+    }
+    
+    private func setupPickerBinding() {
+        Observable.just(ratingOptions)
+            .bind(to: ratePickerView.rx.itemTitles) { _, item in
+                String(format: "%.1f", item)
+            }
+            .disposed(by: disposeBag)
+        
+        ratePickerView.rx.modelSelected(Double.self)
+            .subscribe(onNext: { [weak self] selected in
+                if let rating = selected.first {
+                    self?.rateTextField.text = String(format: "%.1f", rating)
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func setupInputAccessoryView() -> UIToolbar {
+        let toolbar = UIToolbar()
+        toolbar.sizeToFit()
+        
+        let doneButton = UIBarButtonItem(title: "확인", style: .done, target: nil, action: nil)
+        let cancelButton = UIBarButtonItem(title: "취소", style: .plain, target: nil, action: nil)
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        
+        toolbar.setItems([cancelButton, flexibleSpace, doneButton], animated: false)
+        
+        doneButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                print("선택 별점: \(self.rateTextField.text ?? "0.0")")
+                self.rateTextField.resignFirstResponder()
+            })
+            .disposed(by: disposeBag)
+        
+        cancelButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.rateTextField.resignFirstResponder()
+            })
+            .disposed(by: disposeBag)
+        
+        return toolbar
+    }
+    
+    private func showRatePicker() {
+        rateTextField.becomeFirstResponder()
     }
 }

--- a/Todorama/Presentation/Episode/ButtonStack.swift
+++ b/Todorama/Presentation/Episode/ButtonStack.swift
@@ -1,46 +1,18 @@
-//
-//  ButtonStack.swift
-//  Todorama
-//
-//  Created by Claire on 3/22/25.
-//
-
 import UIKit
 import SnapKit
-//
-//final class labelButton: UIView {
-//    private var label: String?
-//    private var image: UIImage?
-//    
-//    
-//    init(label: String, image: UIImage) {
-//        self.label = label
-//        self.image = image
-//    }
-//    
-//    required init?(coder: NSCoder) {
-//        fatalError("init(coder:) has not been implemented")
-//    }
-//    
-//    let iconImageView = UIImageView()
-//    iconImageView.image = image
-//    iconImageView.contentMode = .scaleAspectFit
-//    iconImageView.tintColor = .tdGray
-//    
-//  
-//    titleLabel.text = label
-//    titleLabel.textStyle()
-//    titleLabel.textColor = .tdGray
-//    titleLabel.textAlignment = .center
-//}
+import RxSwift
+import RxCocoa
 
 final class ButtonStack: UIStackView {
+    private let wantToWatchButton = UIButton()
+    private let commentButton = UIButton()
+    private let rateButton = UIButton()
+    
+    private let disposeBag = DisposeBag()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
         setupButtonStack()
-
     }
     
     required init(coder: NSCoder) {
@@ -52,19 +24,18 @@ final class ButtonStack: UIStackView {
         distribution = .equalCentering
         spacing = 40
         
-        let buttons: [(title: String, icon: UIImage)] = [
-            (Strings.Global.wantToWatch.text, SystemImages.plus.image),
-            (Strings.Global.comment.text, SystemImages.pencil.image),
-            (Strings.Global.rate.text, SystemImages.star.image)
+        let buttons = [
+            setupRxButton(wantToWatchButton, title: Strings.Global.wantToWatch.text, icon: SystemImages.plus.image),
+            setupRxButton(commentButton, title: Strings.Global.comment.text, icon: SystemImages.pencil.image),
+            setupRxButton(rateButton, title: Strings.Global.rate.text, icon: SystemImages.star.image)
         ]
         
-        for (title, icon) in buttons {
-            let button = setButton(title: title, icon: icon)
-            addArrangedSubview(button)
-        }
+        buttons.forEach { addArrangedSubview($0) }
+        
+        setupBindings()
     }
     
-    private func setButton(title: String, icon: UIImage) -> UIView {
+    private func setupRxButton(_ button: UIButton, title: String, icon: UIImage) -> UIView {
         let container = UIView()
         
         let iconImageView = UIImageView()
@@ -80,6 +51,7 @@ final class ButtonStack: UIStackView {
         
         container.addSubview(iconImageView)
         container.addSubview(titleLabel)
+        container.addSubview(button)
         
         iconImageView.snp.makeConstraints { make in
             make.top.equalToSuperview()
@@ -93,6 +65,32 @@ final class ButtonStack: UIStackView {
             make.leading.trailing.equalToSuperview()
         }
         
+        button.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        button.backgroundColor = .clear
+        
         return container
+    }
+    
+    private func setupBindings() {
+        wantToWatchButton.rx.tap
+            .subscribe(with: self, onNext: { owner, _ in
+                print("보고싶어요 클릭")
+            })
+            .disposed(by: disposeBag)
+        
+        commentButton.rx.tap
+            .subscribe(with: self, onNext: { owner, _ in
+                print("코멘트 클릭")
+            })
+            .disposed(by: disposeBag)
+        
+        rateButton.rx.tap
+            .subscribe(with: self, onNext: { owner, _ in
+                print("별점 클릭")
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/Todorama/Presentation/Episode/ButtonStack.swift
+++ b/Todorama/Presentation/Episode/ButtonStack.swift
@@ -10,6 +10,8 @@ import RxSwift
 import RxCocoa
 
 final class ButtonStack: UIStackView {
+    // 코멘트 버튼 클릭 이벤트 방출
+    let commentButtonTapped = PublishSubject<Void>()
     
     private let wantToWatchButton = UIButton()
     private let commentButton = UIButton()
@@ -108,6 +110,7 @@ final class ButtonStack: UIStackView {
         commentButton.rx.tap
             .subscribe(with: self, onNext: { owner, _ in
                 print("🌟 COMMENT")
+                owner.commentButtonTapped.onNext(())
             })
             .disposed(by: disposeBag)
         

--- a/Todorama/Presentation/Episode/ButtonStack.swift
+++ b/Todorama/Presentation/Episode/ButtonStack.swift
@@ -4,18 +4,28 @@
 //
 //  Created by Claire on 3/22/25.
 //
+
 import UIKit
 import SnapKit
 import RxSwift
 import RxCocoa
 
 final class ButtonStack: UIStackView {
-    // 코멘트 버튼 클릭 이벤트 방출
     let commentButtonTapped = PublishSubject<Void>()
     
-    private let wantToWatchButton = UIButton()
-    private let commentButton = UIButton()
-    private let rateButton = UIButton()
+    private let wantToWatchButton = IconLabelButton(
+        title: Strings.Global.wantToWatch.text,
+        defaultIcon: SystemImages.plus.image,
+        toggledIcon: SystemImages.heart.image
+    )
+    private let commentButton = IconLabelButton(
+        title: Strings.Global.comment.text,
+        defaultIcon: SystemImages.pencil.image
+    )
+    private let rateButton = IconLabelButton(
+        title: Strings.Global.rate.text,
+        defaultIcon: SystemImages.star.image
+    )
     
     private let ratingOptions: [Double] = Array(stride(from: 0.0, through: 5.0, by: 0.5)).map { $0 }
     
@@ -50,74 +60,31 @@ final class ButtonStack: UIStackView {
         distribution = .equalCentering
         spacing = 40
         
-        let buttons = [
-            setupRxButton(wantToWatchButton, title: Strings.Global.wantToWatch.text, icon: SystemImages.plus.image),
-            setupRxButton(commentButton, title: Strings.Global.comment.text, icon: SystemImages.pencil.image),
-            setupRxButton(rateButton, title: Strings.Global.rate.text, icon: SystemImages.star.image)
-        ]
-        
-        buttons.forEach { addArrangedSubview($0) }
+        [wantToWatchButton, commentButton, rateButton].forEach { addArrangedSubview($0) }
         
         setupBindings()
     }
     
-    private func setupRxButton(_ button: UIButton, title: String, icon: UIImage) -> UIView {
-        let container = UIView()
-        
-        let iconImageView = UIImageView()
-        iconImageView.image = icon
-        iconImageView.contentMode = .scaleAspectFit
-        iconImageView.tintColor = .tdGray
-        
-        let titleLabel = UILabel()
-        titleLabel.text = title
-        titleLabel.accessoryStyle()
-        titleLabel.textColor = .tdGray
-        titleLabel.textAlignment = .center
-        
-        container.addSubview(iconImageView)
-        container.addSubview(titleLabel)
-        container.addSubview(button)
-        
-        iconImageView.snp.makeConstraints { make in
-            make.top.equalToSuperview()
-            make.centerX.equalToSuperview()
-            make.width.height.equalTo(32)
-        }
-        
-        titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(iconImageView.snp.bottom).offset(4)
-            make.centerX.equalToSuperview()
-            make.leading.trailing.equalToSuperview()
-        }
-        
-        button.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
-        
-        button.backgroundColor = .clear
-        
-        return container
-    }
-    
     private func setupBindings() {
         wantToWatchButton.rx.tap
-            .subscribe(with: self, onNext: { owner, _ in
+        
+            .subscribe(onNext: { [weak self] in
                 print("🌟 WANT TO WATCH")
+       
             })
             .disposed(by: disposeBag)
         
         commentButton.rx.tap
-            .subscribe(with: self, onNext: { owner, _ in
+            .subscribe(onNext: { [weak self] in
                 print("🌟 COMMENT")
-                owner.commentButtonTapped.onNext(())
+                self?.commentButtonTapped.onNext(())
             })
             .disposed(by: disposeBag)
         
         rateButton.rx.tap
-            .subscribe(with: self, onNext: { owner, _ in
+            .subscribe(onNext: { [weak self] in
                 print("🌟 RATE")
-                owner.showRatePicker()
+                self?.showRatePicker()
             })
             .disposed(by: disposeBag)
     }
@@ -159,7 +126,9 @@ final class ButtonStack: UIStackView {
         doneButton.rx.tap
             .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
-                print("선택 별점: \(self.rateTextField.text ?? "0.0")")
+                let selectedRating = self.rateTextField.text ?? "0.0"
+                print("선택 별점: \(selectedRating)")
+                self.rateButton.setRating(selectedRating) // 별점 설정
                 self.rateTextField.resignFirstResponder()
             })
             .disposed(by: disposeBag)

--- a/Todorama/Presentation/Episode/EpisodeTableViewCell.swift
+++ b/Todorama/Presentation/Episode/EpisodeTableViewCell.swift
@@ -97,11 +97,11 @@ final class EpisodeTableViewCell: UITableViewCell {
         }
     }
     
-    func bindData(with episode: Episode, dramaId: Int, dramaName: String, seasonNumber: Int) {
+    func bindData(with episode: Episode, dramaId: Int, dramaName: String, seasonId: Int) {
         
         checkButton.setSeries(info: Watching3(dramaId: dramaId,
                                               dramaName: dramaName,
-                                              seasonNumber: seasonNumber,
+                                              seasonId: seasonId,
                                               episodeId: episode.id,
                                               episodeCount: episode.episode_number,
                                               stillCutPath: episode.still_path))

--- a/Todorama/Presentation/Episode/EpisodeTableViewCell.swift
+++ b/Todorama/Presentation/Episode/EpisodeTableViewCell.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 import SnapKit
+import RealmSwift
+import RxCocoa
+import RxSwift
 
 final class EpisodeTableViewCell: UITableViewCell {
 
@@ -15,7 +18,10 @@ final class EpisodeTableViewCell: UITableViewCell {
     private let durationLabel = UILabel()
     private let dateLabel = UILabel()
     private let episodeDescriptionLabel = UILabel()
-    private let checkmarkImageView = UIImageView()
+    private let checkButton = CheckButton()
+
+    private var dramaId: Int? // 드라마 ID를 저장할 변수
+    private let disposeBag = DisposeBag()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -29,7 +35,6 @@ final class EpisodeTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    
     private func configureView() {
         selectionStyle = .none
         
@@ -41,26 +46,19 @@ final class EpisodeTableViewCell: UITableViewCell {
         
         // 텍스트 영역
         episodeNumberLabel.dramaTitleStyle()
-        durationLabel.textStyle() // ✅
+        durationLabel.textStyle()
         dateLabel.textStyle()
         episodeDescriptionLabel.textStyle()
         episodeDescriptionLabel.numberOfLines = 3
-        
-        // 체크 영역 // ✅
-        checkmarkImageView.contentMode = .scaleAspectFit
-        checkmarkImageView.tintColor = .systemYellow
-        checkmarkImageView.image = SystemImages.check.image
-
     }
     
     private func configureHierarchy() {
         [thumbnailImageView,
          episodeNumberLabel, durationLabel, dateLabel, episodeDescriptionLabel,
-         checkmarkImageView].forEach {
+         checkButton].forEach {
             contentView.addSubview($0)
         }
     }
-
     
     private func configureLayout() {
         thumbnailImageView.snp.makeConstraints { make in
@@ -80,7 +78,7 @@ final class EpisodeTableViewCell: UITableViewCell {
             make.leading.equalTo(episodeNumberLabel.snp.leading)
         }
         
-        checkmarkImageView.snp.makeConstraints { make in
+        checkButton.snp.makeConstraints { make in
             make.trailing.equalToSuperview().inset(16)
             make.centerY.equalTo(episodeNumberLabel)
             make.width.height.equalTo(24)
@@ -99,15 +97,19 @@ final class EpisodeTableViewCell: UITableViewCell {
         }
     }
     
-    // MARK: - Configure Cell
-    
-    func bindData(with episode: Episode) {
+    func bindData(with episode: Episode, dramaId: Int, dramaName: String, seasonNumber: Int) {
+        
+        checkButton.setSeries(info: Watching3(dramaId: dramaId,
+                                              dramaName: dramaName,
+                                              seasonNumber: seasonNumber,
+                                              episodeId: episode.id,
+                                              episodeCount: episode.episode_number,
+                                              stillCutPath: episode.still_path))
+        
         thumbnailImageView.kf.setImage(with: URL(string: ImageSize.profile185(url: episode.still_path ?? "").fullUrl))
         episodeNumberLabel.text = "\(episode.episode_number)\(Strings.Unit.epi.text)"
         durationLabel.text = episode.runtime == nil ? "-" : "\(episode.runtime!)\(Strings.Unit.minute.text)"
         dateLabel.text = DateFormatHelper.shared.getFormattedDate(episode.air_date) + " " + "\(Strings.Global.air.text)"
         episodeDescriptionLabel.text = episode.overview
-        checkmarkImageView.tintColor = .tdDarkGray
-//        checkmarkImageView.tintColor = episode.isWatched ? .tdMain : .tdDarkGray
     }
 }

--- a/Todorama/Presentation/Episode/EpisodeTableViewCell.swift
+++ b/Todorama/Presentation/Episode/EpisodeTableViewCell.swift
@@ -109,7 +109,8 @@ final class EpisodeTableViewCell: UITableViewCell {
         thumbnailImageView.kf.setImage(with: URL(string: ImageSize.profile185(url: episode.still_path ?? "").fullUrl))
         episodeNumberLabel.text = "\(episode.episode_number)\(Strings.Unit.epi.text)"
         durationLabel.text = episode.runtime == nil ? "-" : "\(episode.runtime!)\(Strings.Unit.minute.text)"
-        dateLabel.text = DateFormatHelper.shared.getFormattedDate(episode.air_date) + " " + "\(Strings.Global.air.text)"
         episodeDescriptionLabel.text = episode.overview
+        guard let airDate = episode.air_date else { return }
+        dateLabel.text = DateFormatHelper.shared.getFormattedDate(airDate) + " " + "\(Strings.Global.air.text)"
     }
 }

--- a/Todorama/Presentation/Episode/EpisodeViewController.swift
+++ b/Todorama/Presentation/Episode/EpisodeViewController.swift
@@ -21,8 +21,6 @@ final class EpisodeViewController: BaseViewController {
     private let episodesSectionTitleView = SectionTitleView(title: Strings.SectionTitle.episode.text)
     private let episodesTableView = UITableView()
     
-    private lazy var buttonStackView = ButtonStack(drama: Drama())
-    
     init(series: Series, season: Int) {
         self.viewModel = EpisodeViewModel(series: series, season: season)
         super.init(nibName: nil, bundle: nil)
@@ -38,7 +36,7 @@ final class EpisodeViewController: BaseViewController {
     
     override func configureHierarchy() {
         [posterView, dramaTitleLabel, episodeCountLabel, synopsisLabel,
-         episodesSectionTitleView, buttonStackView, episodesTableView].forEach {
+         episodesSectionTitleView, episodesTableView].forEach {
             view.addSubview($0)
         }
     }
@@ -64,16 +62,10 @@ final class EpisodeViewController: BaseViewController {
             make.top.equalTo(episodeCountLabel.snp.bottom).offset(12)
             make.horizontalEdges.equalTo(dramaTitleLabel)
         }
-        
-        buttonStackView.snp.makeConstraints { make in
-            make.top.equalTo(posterView.snp.bottom).offset(24)
-            make.centerX.equalToSuperview()
-            make.height.equalTo(44)
-        }
-        
+
         episodesSectionTitleView.snp.makeConstraints { make in
             make.height.equalTo(44)
-            make.top.equalTo(buttonStackView.snp.bottom).offset(12)
+            make.top.equalTo(posterView.snp.bottom).offset(12)
             make.horizontalEdges.equalToSuperview()
         }
         
@@ -122,16 +114,14 @@ final class EpisodeViewController: BaseViewController {
                 .asDriver(onErrorJustReturn: [])
                 .drive(episodesTableView.rx.items(cellIdentifier: EpisodeTableViewCell.identifier, cellType: EpisodeTableViewCell.self)) { [weak self] row, episode, cell in
                     guard let self = self else { return }
-                    cell.bindData(with: episode, dramaId: self.viewModel.series.id)
+
+                    cell.bindData(with: episode,
+                                  dramaId: self.viewModel.series.id,
+                                  dramaName: self.viewModel.series.name,
+                                  seasonNumber: self.viewModel.series.number_of_seasons)
                 }
                 .disposed(by: disposeBag)
         
-        buttonStackView.commentButtonTapped
-            .subscribe(with: self, onNext: { owner, _ in
-                let controller = EditingCommentViewController()
-                owner.navigationController?.pushViewController(controller, animated: true)
-            })
-            .disposed(by: disposeBag)
     }
     
     

--- a/Todorama/Presentation/Episode/EpisodeViewController.swift
+++ b/Todorama/Presentation/Episode/EpisodeViewController.swift
@@ -21,8 +21,8 @@ final class EpisodeViewController: BaseViewController {
     private let episodesSectionTitleView = SectionTitleView(title: Strings.SectionTitle.episode.text)
     private let episodesTableView = UITableView()
     
-    init(series: Series, season: Int) {
-        self.viewModel = EpisodeViewModel(series: series, season: season)
+    init(series: Series, season: Int, seasonId: Int) {
+        self.viewModel = EpisodeViewModel(series: series, season: season, seasonId: seasonId)
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -77,6 +77,8 @@ final class EpisodeViewController: BaseViewController {
     }
     
     override func configureView() {
+        navigationItem.title = viewModel.series.name
+        
         posterView.backgroundColor = .tdWhite
         posterView.layer.cornerRadius = 4
         posterView.contentMode = .scaleAspectFill
@@ -118,7 +120,7 @@ final class EpisodeViewController: BaseViewController {
                     cell.bindData(with: episode,
                                   dramaId: self.viewModel.series.id,
                                   dramaName: self.viewModel.series.name,
-                                  seasonNumber: self.viewModel.series.number_of_seasons)
+                                  seasonId: self.viewModel.seasonId)
                 }
                 .disposed(by: disposeBag)
         
@@ -137,7 +139,6 @@ final class EpisodeViewController: BaseViewController {
     }
     
     private func loadData(with seasonDetail: SeasonDetail) {
-
         dramaTitleLabel.text = seasonDetail.name
         episodeCountLabel.text = "\(seasonDetail.season_number)\(Strings.Unit.count.text) \(Strings.Global.episode.text)"
         synopsisLabel.text = seasonDetail.overview

--- a/Todorama/Presentation/Episode/EpisodeViewController.swift
+++ b/Todorama/Presentation/Episode/EpisodeViewController.swift
@@ -101,7 +101,7 @@ final class EpisodeViewController: BaseViewController {
             .asDriver(onErrorJustReturn: SeasonDetail(name: "", overview: "", id: -1, poster_path: "", season_number: -1, episodes: []))
             .drive(with: self, onNext: { owner, detail in
                 owner.dramaTitleLabel.text = detail.name
-                owner.episodeCountLabel.text = "\(detail.season_number)\(Strings.Unit.count.text) \(Strings.Global.episode.text)"
+                owner.episodeCountLabel.text = detail.season_number != 0 ? "\(detail.season_number)\(Strings.Unit.count.text) \(Strings.Global.episode.text)" : Strings.Global.empty.text
                 owner.synopsisLabel.text = detail.overview
                 if let posterPath = detail.poster_path {
                     owner.posterView.kf.setImage(with: URL(string: ImageSize.poster185(url: posterPath).fullUrl))

--- a/Todorama/Presentation/Episode/EpisodeViewController.swift
+++ b/Todorama/Presentation/Episode/EpisodeViewController.swift
@@ -12,7 +12,6 @@ import SnapKit
 
 final class EpisodeViewController: BaseViewController {
     private let disposeBag = DisposeBag()
-//    private var series: Series
     private var viewModel: EpisodeViewModel
     
     private let posterView = UIImageView()
@@ -104,19 +103,13 @@ final class EpisodeViewController: BaseViewController {
     override func bind() {
         let input = EpisodeViewModel.Input()
         let output = viewModel.transform(input: input)
-        
-        
-        
-//        output.result
- //            .map { $0.seasons }
- //            .asDriver(onErrorJustReturn: [])
- //            .drive(seriesCollectionView.rx.items(
- //                cellIdentifier: SeriesCollectionViewCell.identifier,
- //                cellType: SeriesCollectionViewCell.self)) {(row, element, cell) in
- //
- //                cell.bindData(with: element)
- //            }
- //            .disposed(by: disposeBag)
+
+        buttonStackView.commentButtonTapped
+                    .subscribe(onNext: { [weak self] in
+                        let controller = EditingCommentViewController()
+                        self?.navigationController?.pushViewController(controller, animated: true)
+                    })
+                    .disposed(by: disposeBag)
         
         output.result
             .asDriver(onErrorJustReturn: SeasonDetail(name: "", overview: "", id: -1, poster_path: "", season_number: -1, episodes: []))
@@ -134,23 +127,7 @@ final class EpisodeViewController: BaseViewController {
                      .disposed(by: owner.disposeBag)
              })
              .disposed(by: disposeBag)
-        
-//        output.result
-//            .map { $0.episodes }
-//            .asDriver(onErrorJustReturn: [])
-//            .drive(episodesTableView.rx.items(
-//                cellIdentifier: EpisodeTableViewCell.identifier,
-//                cellType: EpisodeTableViewCell.self)) {(row, element, cell) in
-//                    cell.bindData(with: element)
-//                    self.loadData(with: element)
-//                }
-//            .disposed(by: disposeBag)
-   
-//        episodesTableView.rx.itemSelected
-//            .subscribe(onNext: { [weak self] indexPath in
-//                self?.episodesTableView.deselectRow(at: indexPath, animated: true)
-//            })
-//            .disposed(by: disposeBag)
+
     }
     
     

--- a/Todorama/Presentation/Episode/EpisodeViewModel.swift
+++ b/Todorama/Presentation/Episode/EpisodeViewModel.swift
@@ -14,10 +14,12 @@ final class EpisodeViewModel: BaseViewModel {
     
     let series: Series
     let season: Int
+    let seasonId: Int
     
-    init(series: Series, season: Int) {
+    init(series: Series, season: Int, seasonId: Int) {
         self.series = series
         self.season = season
+        self.seasonId = seasonId
     }
     
     struct Input {

--- a/Todorama/Presentation/Episode/EpisodeViewModel.swift
+++ b/Todorama/Presentation/Episode/EpisodeViewModel.swift
@@ -12,11 +12,11 @@ import RxSwift
 final class EpisodeViewModel: BaseViewModel {
     let disposeBag = DisposeBag()
     
-    let id: Int
+    let series: Series
     let season: Int
     
-    init(id: Int, season: Int) {
-        self.id = id
+    init(series: Series, season: Int) {
+        self.series = series
         self.season = season
     }
     
@@ -31,7 +31,7 @@ final class EpisodeViewModel: BaseViewModel {
     func transform(input: Input) -> Output {
         let result = PublishSubject<SeasonDetail>()
         
-        NetworkManager.shared.callRequest(target: .episode(id: id, season: season), model: SeasonDetail.self)
+        NetworkManager.shared.callRequest(target: .episode(id: series.id, season: season), model: SeasonDetail.self)
             .share(replay: 1, scope: .whileConnected)
             .subscribe(with: self) { owner, response in
                 result.onNext(response)

--- a/Todorama/Presentation/Episode/IconLabelButton.swift
+++ b/Todorama/Presentation/Episode/IconLabelButton.swift
@@ -1,0 +1,106 @@
+//
+//  IconLabelButton.swift
+//  Todorama
+//
+//  Created by Claire on 3/24/25.
+//
+
+import UIKit
+import RxSwift
+import SnapKit
+
+final class IconLabelButton: UIButton {
+    private let iconImageView = UIImageView()
+    private let label = UILabel()
+    private let disposeBag = DisposeBag()
+    
+    var isToggled = false {
+        didSet {
+            updateAppearance()
+        }
+    }
+    
+    private var rating: String? {
+        didSet {
+            updateRatingAppearance()
+        }
+    }
+    
+    private let defaultIcon: UIImage
+    
+    init(title: String, defaultIcon: UIImage, toggledIcon: UIImage? = nil) {
+        self.defaultIcon = defaultIcon
+        super.init(frame: .zero)
+        setupUI(title: title, defaultIcon: defaultIcon)
+        setupBindings(toggledIcon: toggledIcon)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI(title: String, defaultIcon: UIImage) {
+        iconImageView.image = defaultIcon
+        iconImageView.contentMode = .scaleAspectFit
+        iconImageView.tintColor = .tdGray
+        
+        label.text = title
+        label.accessoryStyle()
+        label.textColor = .tdGray
+        label.textAlignment = .center
+        
+        addSubview(iconImageView)
+        addSubview(label)
+        
+        iconImageView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.centerX.equalToSuperview()
+            make.width.height.equalTo(32)
+        }
+        
+        label.snp.makeConstraints { make in
+            make.top.equalTo(iconImageView.snp.bottom).offset(4)
+            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
+        }
+        
+        backgroundColor = .clear
+    }
+    
+    private func setupBindings(toggledIcon: UIImage?) {
+        rx.tap
+            .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                self.isToggled.toggle()
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func updateAppearance() {
+        if isToggled {
+//            iconImageView.image = SystemImages.heart.image
+            iconImageView.tintColor = .tdMain
+            label.textColor = .tdMain
+        } else {
+//            iconImageView.image = defaultIcon
+            iconImageView.tintColor = .tdGray
+            label.textColor = .tdGray
+        }
+    }
+    
+    private func updateRatingAppearance() {
+        if let rating = rating {
+            label.text = rating
+            iconImageView.tintColor = .tdMain
+            label.textColor = .tdMain
+        } else {
+            label.text = Strings.Global.rate.text
+            iconImageView.tintColor = .tdGray
+            label.textColor = .tdGray
+        }
+    }
+
+    func setRating(_ rating: String?) {
+        self.rating = rating
+    }
+}

--- a/Todorama/Presentation/Series/SeriesViewController.swift
+++ b/Todorama/Presentation/Series/SeriesViewController.swift
@@ -39,6 +39,7 @@ final class SeriesViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
     }
     
     override func bind() {
@@ -81,7 +82,9 @@ final class SeriesViewController: BaseViewController {
             .subscribe(onNext: { [weak self] indexPath, series in
                 guard indexPath.row < series.seasons.count else { return }
                 let selectedSeason = series.seasons[indexPath.row]
-                let controller = EpisodeViewController(id: series.id, season: selectedSeason.season_number)
+                
+                let controller = EpisodeViewController(series: series,
+                                                       season: selectedSeason.season_number)
                 self?.navigationController?.pushViewController(controller, animated: true)
             })
             .disposed(by: disposeBag)

--- a/Todorama/Presentation/Series/SeriesViewController.swift
+++ b/Todorama/Presentation/Series/SeriesViewController.swift
@@ -88,7 +88,8 @@ final class SeriesViewController: BaseViewController {
                 let selectedSeason = series.seasons[indexPath.row]
                 
                 let controller = EpisodeViewController(series: series,
-                                                       season: selectedSeason.season_number)
+                                                       season: selectedSeason.season_number,
+                                                       seasonId: selectedSeason.id)
                 self?.navigationController?.pushViewController(controller, animated: true)
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타: 변경사항

### 반영 브랜치
38-feat-episode-button -> main

### 변경 사항
- 기존 스택버튼 제거
- 시리즈 화면에서 보고싶어요(하트모양) 버튼 클릭시 Realm에 저장
- 에피소드 화면에서 시즌별 에피소드 진행률 Realm에 저장
- 방영일 없을 경우 발견 -> 데이터 타입 옵셔널 처리
- 에피소드 0으로 나올 경우 빈문자열로 대체

### 테스트 사항
- Realm Studio를 통해서 보고싶은 시리즈를 기준으로 저장되는 것을 확인했습니다.
- Realm Studio를 통해서 시즌 아이디 기준으로 에피소드가 저장되는 것을 확인했습니다.

